### PR TITLE
Make parser compatible with one-value truth value

### DIFF
--- a/NALGrammar/Sentences.py
+++ b/NALGrammar/Sentences.py
@@ -333,7 +333,6 @@ def new_sentence_from_string(sentence_string: str):
     elif truth_value_found:
         # Parse single truth value (f) from string, with reference to OpenNARS
         freq = float(sentence_string[start_truth_val_idx + 1:end_truth_val_idx])
-        conf = 0.9 # default confidence is 0.9
 
     # create the statement
     statement_string = sentence_string[start_idx:end_idx + 1]

--- a/NALGrammar/Sentences.py
+++ b/NALGrammar/Sentences.py
@@ -323,12 +323,17 @@ def new_sentence_from_string(sentence_string: str):
     end_truth_val_idx = sentence_string.rfind(NALSyntax.StatementSyntax.TruthValMarker.value, punctuation_idx)
 
     truth_value_found = not (start_truth_val_idx == -1 or end_truth_val_idx == -1 or start_truth_val_idx == end_truth_val_idx)
+    has_full_truth_value = middle_truth_val_idx != -1
     freq = None
     conf = None
-    if truth_value_found:
-        # Parse truth value from string
+    if has_full_truth_value:
+        # Parse truth value from string with specified frequency and confidence
         freq = float(sentence_string[start_truth_val_idx + 1:middle_truth_val_idx])
         conf = float(sentence_string[middle_truth_val_idx + 1:end_truth_val_idx])
+    elif truth_value_found:
+        # Parse single truth value (f) from string, with reference to OpenNARS
+        freq = float(sentence_string[start_truth_val_idx + 1:end_truth_val_idx])
+        conf = 0.9 # default confidence is 0.9
 
     # create the statement
     statement_string = sentence_string[start_idx:end_idx + 1]


### PR DESCRIPTION
## ✨New Feature

Make the Narsese parser compatible with one-value truth value(only frequency)

Example: `(A --> B). %1.0%` will be input as `(A --> B). %1.0; 0.9%`

## 📄Reference

OpenNARS: 
![image](https://github.com/ccrock4t/NARS-Python/assets/61109168/462103e4-334b-425a-ba88-c2ae21ccb3bc)

PyNARS
![image](https://github.com/ccrock4t/NARS-Python/assets/61109168/58fc98ee-5d50-468e-b2c6-811940c9fc41)
